### PR TITLE
feat: feature-gate combine/assembler for binary size reduction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ include = [
 # standard library when the crate is compiled for no_std
 byteorder = { version = "1.5", default-features = false }
 log = { version = "0.4", default-features = false }
-combine = { version = "4.6", default-features = false }
+combine = { version = "4.6", default-features = false, optional = true }
 
 # Optional Dependencies when using the standard library
 libc = { version = "0.2", optional = true }
@@ -49,8 +49,9 @@ json = "0.12"
 hex = "0.4.3"
 
 [features]
-default = ["std"]
-std = ["dep:libc", "combine/std"]
+default = ["std", "assembler"]
+assembler = ["dep:combine"]
+std = ["dep:libc", "combine?/std"]
 cranelift = [
     "dep:cranelift-codegen",
     "dep:cranelift-frontend",

--- a/README.md
+++ b/README.md
@@ -487,6 +487,8 @@ methods are available.
 The first method consists in using the assembler provided by the crate.
 
 ```rust
+# #[cfg(feature = "assembler")]
+# {
 extern crate rbpf;
 use rbpf::assembler::assemble;
 
@@ -500,6 +502,7 @@ let prog = assemble("add64 r1, 0x605
 #[cfg(feature = "std")] {
     println!("{:?}", prog);
 }
+# }
 ```
 
 The above snippet will produce:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate byteorder;
+#[cfg(feature = "assembler")]
 extern crate combine;
 extern crate log;
 
@@ -36,7 +37,9 @@ use byteorder::{ByteOrder, LittleEndian};
 use core::ops::Range;
 use stack::{StackUsage, StackVerifier};
 
+#[cfg(feature = "assembler")]
 mod asm_parser;
+#[cfg(feature = "assembler")]
 pub mod assembler;
 #[cfg(feature = "cranelift")]
 mod cranelift;

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 // Copyright 2017 Rich Lane <lanerl@gmail.com>
 
+#![cfg(feature = "assembler")]
+
 extern crate rbpf;
 mod common;
 

--- a/tests/cranelift.rs
+++ b/tests/cranelift.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-#![cfg(feature = "cranelift")]
+#![cfg(all(feature = "cranelift", feature = "assembler"))]
 
 extern crate rbpf;
 mod common;

--- a/tests/disassembler.rs
+++ b/tests/disassembler.rs
@@ -3,6 +3,8 @@
 //
 // Adopted from tests in `tests/assembler.rs`
 
+#![cfg(feature = "assembler")]
+
 extern crate rbpf;
 mod common;
 

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -15,6 +15,7 @@
 
 extern crate rbpf;
 
+#[cfg(feature = "assembler")]
 use rbpf::assembler::assemble;
 #[cfg(feature = "std")]
 use rbpf::helpers;
@@ -102,7 +103,7 @@ fn alloc_exec_memory() -> Box<[u8]> {
 }
 
 #[test]
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "assembler"))]
 fn test_vm_block_port() {
     // To load the bytecode from an object file instead of using the hardcoded instructions,
     // use the additional crates commented at the beginning of this file (and also add them to your
@@ -194,7 +195,7 @@ fn test_vm_block_port() {
 }
 
 #[test]
-#[cfg(all(not(windows), feature = "std"))]
+#[cfg(all(not(windows), feature = "std", feature = "assembler"))]
 fn test_jit_block_port() {
     // To load the bytecode from an object file instead of using the hardcoded instructions,
     // use the additional crates commented at the beginning of this file (and also add them to your
@@ -669,6 +670,7 @@ fn verifier_fail(_prog: &[u8]) -> Result<(), Error> {
 }
 
 #[test]
+#[cfg(feature = "assembler")]
 fn test_verifier_success() {
     let prog = assemble(
         "mov32 r0, 0xBEE
@@ -682,6 +684,7 @@ fn test_verifier_success() {
 }
 
 #[test]
+#[cfg(feature = "assembler")]
 #[should_panic(expected = "Gaggablaghblagh!")]
 fn test_verifier_fail() {
     let prog = assemble(
@@ -696,6 +699,7 @@ fn test_verifier_fail() {
 }
 
 #[test]
+#[cfg(feature = "assembler")]
 fn test_vm_bpf_to_bpf_call() {
     let test_code = assemble(
         "
@@ -720,7 +724,7 @@ fn test_vm_bpf_to_bpf_call() {
     assert_eq!(vm_res, 0x10);
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), feature = "assembler"))]
 #[test]
 fn test_vm_jit_bpf_to_bpf_call() {
     let test_code = assemble(
@@ -798,6 +802,7 @@ fn test_vm_jit_other_type_call() {
 }
 
 #[test]
+#[cfg(feature = "assembler")]
 #[should_panic(expected = "Error: out of bounds memory store (insn #8)")]
 fn test_stack_overflow() {
     // The stdw instruction is used to test the stack overflow.

--- a/tests/ubpf_jit_x86_64.rs
+++ b/tests/ubpf_jit_x86_64.rs
@@ -16,7 +16,7 @@
 
 // These are unit tests for the eBPF JIT compiler.
 
-#![cfg(not(windows))]
+#![cfg(all(not(windows), feature = "assembler"))]
 
 extern crate rbpf;
 mod common;

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -16,6 +16,8 @@
 
 // These are unit tests for the eBPF “verifier”.
 
+#![cfg(feature = "assembler")]
+
 extern crate rbpf;
 
 use rbpf::assembler::assemble;

--- a/tests/ubpf_vm.rs
+++ b/tests/ubpf_vm.rs
@@ -16,6 +16,8 @@
 
 // These are unit tests for the eBPF interpreter.
 
+#![cfg(feature = "assembler")]
+
 extern crate rbpf;
 mod common;
 


### PR DESCRIPTION
## Summary

Adds an `assembler` Cargo feature that gates the `combine` parser combinator dependency along with the `asm_parser` and `assembler` modules. This allows downstream consumers who only need the VM/interpreter to avoid pulling in the parser combinator crate entirely, reducing dependency count and binary size.

## Changes

- **Cargo.toml**: Make `combine` optional, add `assembler` feature, include in `default` for backward compatibility, use weak dep syntax
- **src/lib.rs**: Gate `extern crate combine`, `mod asm_parser`, `pub mod assembler` behind `#[cfg(feature = "assembler")]`
- **Test files**: Add `#![cfg(feature = "assembler")]` gates to test files that depend on assembler
- **README.md**: Wrap assembler doctest in hidden cfg block so it compiles when feature is off

## Usage

`	oml
# Full functionality (default, backward compatible)
rbpf = "0.4.1"

# Without assembler/combine for smaller binaries
rbpf = { version = "0.4.1", default-features = false, features = ["std"] }
`

## Verification

- `cargo check` (default features) - pass
- `cargo check --no-default-features` (no_std, no assembler) - pass
- `cargo check --no-default-features --features std` (std without assembler) - pass
- `cargo test` (all tests pass with defaults) - pass
- `cargo test --no-default-features` (non-assembler tests pass) - pass
